### PR TITLE
usable Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,14 @@ OBJDIR := $(BUILDDIR)/obj
 ARCHDIR := $(SRCDIR)/arch/i686
 
 CC := i686-elf-gcc
-CFLAGS := -O2 -g -ffreestanding -Wall -Wextra -m32
+CFLAGS := -O2 -g -ffreestanding -Wall -Wextra -m32 -Iinclude/kernel
 LDFLAGS := -T $(ARCHDIR)/linker.ld
 AS := nasm
 LIBS := -nostdlib -lgcc
 BINARY := $(BUILDDIR)/canoos.kernel
 
-KERNEL_SRC := $(wildcard $(SRCDIR)/kernel/*.c)
+KERNEL_SRC := $(wildcard $(SRCDIR)/kernel/*/*.c)
+KERNEL_SRC += $(wildcard $(SRCDIR)/kernel/*.c)
 KERNEL_OBJ := $(patsubst $(SRCDIR)/kernel/%.c,$(OBJDIR)/%.o,$(KERNEL_SRC))
 
 ARCH_SRC := $(wildcard $(ARCHDIR)/*.asm)
@@ -31,10 +32,13 @@ $(KERNEL_OBJ): $(OBJDIR)/%.o : $(SRCDIR)/kernel/%.c
 link:
 	$(CC) $(LDFLAGS) $(ARCH_OBJ) $(KERNEL_OBJ) -o $(BINARY) $(LIBS)
 
+run:
+	qemu-system-i386 -kernel build/canoos.kernel
+
 destroy:
 	rm -rf $(BUILDDIR)
 
 clean:
 	rm -rf $(OBJDIR)
 
-.PHONY: canoos-all build destroy clean
+.PHONY: canoos-all build link run destroy clean

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The Makefile depends on the following tools:
 - nasm
 - i686-elf-gcc
 - i686-elf-binutils
+- qemu for i386
 
 You can either install the i686-elf versions of gcc and binutils using your favourite package manager or build them from source using the [setup.sh](https://github.com/Garihosu/CanoOS/blob/main/setup.sh) script.
 

--- a/run-qemu.sh
+++ b/run-qemu.sh
@@ -7,4 +7,3 @@ if ! [ -x "$(command -v qemu-system-i386)" ]; then
 fi
 
 qemu-system-i386 -kernel build/kernel/canoos.kernel
-

--- a/setup.sh
+++ b/setup.sh
@@ -9,9 +9,7 @@ BINUTILSNAME="binutils-2.42"
 BINUTILSURL="https://ftp.gnu.org/gnu/binutils/$BINUTILSNAME.tar.gz"
 BINUTILSDIR="$BUILDDIR/$BINUTILSNAME"
 
-MAKE_FLAGS=-j$(nproc)
-
-function download_build() {  
+function download_build() {
     set -xe
     
     mkdir -p $BUILDDIR
@@ -24,8 +22,8 @@ function download_build() {
     mkdir -p $BINUTILSDIR-build
     cd $BINUTILSDIR-build
     ../$BINUTILSNAME/configure --target=i686-elf --prefix="$(pwd)" --with-sysroot --disable-nls --disable-werror
-    make $MAKE_FLAGS
-    make install $MAKE_FLAGS
+    make
+    make install
 
     cd ../../../
 
@@ -40,10 +38,10 @@ function download_build() {
     mkdir -p $GCCDIR-build
     cd $GCCDIR-build
     ../$GCCNAME/configure --target=i686-elf --prefix="$(pwd)" --disable-nls --enable-languages=c,c++ --without-headers --disable-multilib --disable-build-format-warnings
-    make all-gcc $MAKE_FLAGS
-    make all-target-libgcc $MAKE_FLAGS
-    make install-gcc $MAKE_FLAGS
-    make install-target-libgcc $MAKE_FLAGS
+    make all-gcc
+    make all-target-libgcc
+    make install-gcc
+    make install-target-libgcc
 
     cd ../../../
 

--- a/src/kernel/drivers/tty.c
+++ b/src/kernel/drivers/tty.c
@@ -1,4 +1,4 @@
-
+#include <drivers/tty.h>
 #include <stdint.h>
 #include <stddef.h>
 

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -1,10 +1,8 @@
-
 #include "drivers/tty.h"
 
 void kernel_main(void)
 {
 	cls();
-
 	puts("Hello, world!\n");
 }
 


### PR DESCRIPTION
The Makefile is tested and ready to use. `build.sh` and `run-qemu.sh` may be removed in later patches, I've left them for portability reasons, the Makefile should be tested on other Linux distros first (it should work fine tho).